### PR TITLE
Fix has_downloads drift: set false fleet-wide to match GitHub

### DIFF
--- a/repos/JollyJack.yaml
+++ b/repos/JollyJack.yaml
@@ -15,7 +15,7 @@ default_branch: master
 delete_branch_on_merge: false
 description: A repository for testing the GitHub Terraformer action
 has_discussions: false
-has_downloads: true
+has_downloads: false
 has_issues: false
 has_projects: true
 has_wiki: false

--- a/repos/consuldotnet.yaml
+++ b/repos/consuldotnet.yaml
@@ -5,7 +5,7 @@ default_branch: master
 has_issues: false
 has_projects: true
 has_wiki: true
-has_downloads: true
+has_downloads: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/repos/operative-work.yaml
+++ b/repos/operative-work.yaml
@@ -3,7 +3,7 @@ default_branch: main
 has_issues: true
 has_projects: true
 has_wiki: true
-has_downloads: true
+has_downloads: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/repos/ospo-platform.yaml
+++ b/repos/ospo-platform.yaml
@@ -4,7 +4,7 @@ default_branch: main
 has_issues: true
 has_projects: true
 has_wiki: true
-has_downloads: true
+has_downloads: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/repos/perfetto.yaml
+++ b/repos/perfetto.yaml
@@ -5,7 +5,7 @@ default_branch: rebased-v49-jane-public-patches
 has_issues: false
 has_projects: true
 has_wiki: false
-has_downloads: true
+has_downloads: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/repos/repo1.yaml
+++ b/repos/repo1.yaml
@@ -5,7 +5,7 @@ default_branch: main
 has_issues: true
 has_projects: true
 has_wiki: false
-has_downloads: true
+has_downloads: false
 allow_merge_commit: true
 allow_rebase_merge: false
 allow_squash_merge: false

--- a/repos/repo2.yaml
+++ b/repos/repo2.yaml
@@ -5,7 +5,7 @@ default_branch: main
 has_issues: true
 has_projects: false
 has_wiki: false
-has_downloads: true
+has_downloads: false
 allow_merge_commit: true
 allow_rebase_merge: false
 allow_squash_merge: false

--- a/repos/repo3.yaml
+++ b/repos/repo3.yaml
@@ -5,7 +5,7 @@ default_branch: main
 has_issues: true
 has_projects: true
 has_wiki: false
-has_downloads: true
+has_downloads: false
 allow_merge_commit: true
 allow_rebase_merge: false
 allow_squash_merge: false

--- a/repos/repo4.yaml
+++ b/repos/repo4.yaml
@@ -4,7 +4,7 @@ default_branch: main
 has_issues: true
 has_projects: true
 has_wiki: false
-has_downloads: true
+has_downloads: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/repos/repo5.yaml
+++ b/repos/repo5.yaml
@@ -5,7 +5,7 @@ description: A repository for testing the GitHub Terraformer action
 has_issues: true
 has_projects: true
 has_wiki: true
-has_downloads: true
+has_downloads: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/repos/repo6.yaml
+++ b/repos/repo6.yaml
@@ -4,7 +4,7 @@ default_branch: main
 has_issues: false
 has_projects: true
 has_wiki: true
-has_downloads: true
+has_downloads: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/repos/repo7.yaml
+++ b/repos/repo7.yaml
@@ -4,7 +4,7 @@ default_branch: main
 has_issues: true
 has_projects: true
 has_wiki: true
-has_downloads: true
+has_downloads: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/repos/repo8.yaml
+++ b/repos/repo8.yaml
@@ -5,7 +5,7 @@ default_branch: main
 has_issues: true
 has_projects: true
 has_wiki: false
-has_downloads: true
+has_downloads: false
 allow_merge_commit: true
 allow_rebase_merge: false
 allow_squash_merge: false

--- a/repos/repo9.yaml
+++ b/repos/repo9.yaml
@@ -5,7 +5,7 @@ default_branch: master
 has_issues: true
 has_projects: true
 has_wiki: false
-has_downloads: true
+has_downloads: false
 allow_merge_commit: true
 allow_rebase_merge: false
 allow_squash_merge: false

--- a/repos/tada.yaml
+++ b/repos/tada.yaml
@@ -3,7 +3,7 @@ default_branch: main
 has_issues: true
 has_projects: true
 has_wiki: true
-has_downloads: true
+has_downloads: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/repos/test-repo.yaml
+++ b/repos/test-repo.yaml
@@ -3,7 +3,7 @@ default_branch: main
 has_issues: true
 has_projects: true
 has_wiki: true
-has_downloads: true
+has_downloads: false
 allow_merge_commit: false
 allow_rebase_merge: false
 allow_squash_merge: true

--- a/repos/test-repo2.yaml
+++ b/repos/test-repo2.yaml
@@ -3,7 +3,7 @@ default_branch: main
 has_issues: true
 has_projects: true
 has_wiki: true
-has_downloads: true
+has_downloads: false
 allow_merge_commit: false
 allow_rebase_merge: false
 allow_squash_merge: true

--- a/repos/test-sboms.yaml
+++ b/repos/test-sboms.yaml
@@ -4,7 +4,7 @@ default_branch: main
 has_issues: true
 has_projects: true
 has_wiki: true
-has_downloads: true
+has_downloads: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true


### PR DESCRIPTION
GitHub removed the legacy repository *Downloads* feature (2012) and no longer allows `has_downloads` to be enabled — the API keeps it `false`. Our configs still say `true`, so the drift-check reports them and any apply that PATCHes these repos would re-drift.

Sets `has_downloads: false` fleet-wide to match GitHub, clearing the drift. Mechanical — only the `has_downloads` line changes per file. No apply-time behaviour change (GitHub already has these at `false`).

Verified on G-Research: `PATCH has_downloads=true` returns `false` — GitHub refuses to enable it.