### PR TITLE
Bump github-terraformer to v0.2.6

### DIFF
--- a/.github/workflows/bulk-import.yaml
+++ b/.github/workflows/bulk-import.yaml
@@ -5,8 +5,8 @@ on:
 
 jobs:
   bulk-import-repos:
-    uses: G-Research/github-terraformer/.github/workflows/bulk-import.yaml@v0.2.5
+    uses: G-Research/github-terraformer/.github/workflows/bulk-import.yaml@v0.2.6
     with:
-      gcss_ref: v0.2.5
+      gcss_ref: v0.2.6
     secrets:
       app_private_key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/create-fork.yaml
+++ b/.github/workflows/create-fork.yaml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   create-fork:
-    uses: G-Research/github-terraformer/.github/workflows/create-fork.yaml@v0.2.5
+    uses: G-Research/github-terraformer/.github/workflows/create-fork.yaml@v0.2.6
     with:
       upstream_repo: ${{ github.event.inputs.upstream_repo }}
       fork_name: ${{ github.event.inputs.fork_name }}

--- a/.github/workflows/drift-check.yaml
+++ b/.github/workflows/drift-check.yaml
@@ -9,7 +9,7 @@ jobs:
   drift-check:
     secrets:
       tfc_token: ${{ secrets.TFC_TOKEN }}
-    uses: G-Research/github-terraformer/.github/workflows/drift-check.yaml@v0.2.5
+    uses: G-Research/github-terraformer/.github/workflows/drift-check.yaml@v0.2.6
     with:
-      gcss_ref: v0.2.5
+      gcss_ref: v0.2.6
       tfc_org: "GR-OSS"

--- a/.github/workflows/import.yaml
+++ b/.github/workflows/import.yaml
@@ -9,9 +9,9 @@ on:
 
 jobs:
   import-repo:
-    uses: G-Research/github-terraformer/.github/workflows/import.yaml@v0.2.5
+    uses: G-Research/github-terraformer/.github/workflows/import.yaml@v0.2.6
     with:
       repo_name: ${{ github.event.inputs.repo_name }}
-      gcss_ref: v0.2.5
+      gcss_ref: v0.2.6
     secrets:
         app_private_key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/promote-imported-configs.yaml
+++ b/.github/workflows/promote-imported-configs.yaml
@@ -10,10 +10,10 @@ on:
 jobs:
   promote:
     if: github.event.pull_request.merged == true
-    uses: G-Research/github-terraformer/.github/workflows/promote-imported-configs.yaml@v0.2.5
+    uses: G-Research/github-terraformer/.github/workflows/promote-imported-configs.yaml@v0.2.6
     with:
       commit_sha: ${{ github.event.pull_request.merge_commit_sha }}
-      gcss_ref: v0.2.5
+      gcss_ref: v0.2.6
       pr_number: ${{ github.event.pull_request.number }}
       tfc_org: "GR-OSS"
     secrets:

--- a/.github/workflows/tf-apply.yaml
+++ b/.github/workflows/tf-apply.yaml
@@ -8,10 +8,10 @@ on:
 
 jobs:
   terraform-apply:
-    uses: G-Research/github-terraformer/.github/workflows/tf-apply.yaml@v0.2.5
+    uses: G-Research/github-terraformer/.github/workflows/tf-apply.yaml@v0.2.6
     with:
       commit_sha: ${{ github.sha }}
-      gcss_ref: v0.2.5
+      gcss_ref: v0.2.6
       tfc_org: "GR-OSS"
     secrets:
       gh_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tf-plan.yaml
+++ b/.github/workflows/tf-plan.yaml
@@ -8,10 +8,10 @@ on:
 
 jobs:
   terraform-plan:
-    uses: G-Research/github-terraformer/.github/workflows/tf-plan.yaml@v0.2.5
+    uses: G-Research/github-terraformer/.github/workflows/tf-plan.yaml@v0.2.6
     with:
       commit_sha: ${{ github.event.workflow_run.head_sha }}
-      gcss_ref: v0.2.5
+      gcss_ref: v0.2.6
       tfc_org: "GR-OSS"
     secrets:
       app_private_key: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
Bumps the pinned `G-Research/github-terraformer` version from v0.2.5 to **v0.2.6** across all caller workflows.

Both references are moved together in each workflow file:
- reusable-workflow ref `...@v0.2.5` → `@v0.2.6`
- `gcss_ref: v0.2.5` → `gcss_ref: v0.2.6`

v0.2.6 is a CI/security-hardening release (all GitHub Actions pinned to commit SHAs, #44) — no product, Terraform, or Go behavior changes.
Release: https://github.com/G-Research/github-terraformer/releases/tag/v0.2.6