### PR TITLE
consuldotnet: fix misspelled update_allows_fetch_and_merge

### DIFF
--- a/repos/consuldotnet.yaml
+++ b/repos/consuldotnet.yaml
@@ -28,7 +28,7 @@ rulesets:
       deletion: true
       non_fast_forward: true
       update: true
-      update_allow_fetch_and_merge: false
+      update_allows_fetch_and_merge: true
       required_status_checks:
         required_check:
           - context: all-required-checks-complete


### PR DESCRIPTION
The key was written as `update_allow_fetch_and_merge`, missing the `s`.

Terraform reads `update_allows_fetch_and_merge`, found nothing, and passed `null` — so the
setting was never managed. The config asked for `false` while the live ruleset has stayed
`true` all along. The misspelled key was silently ignored by everything.

Surfaced by the schema validation gate, which rejects unknown properties.

Adopts the live value (`true`) so the corrected key produces no change. Switching it to
`false` is a real ruleset change and belongs in its own pull request.

Note: this cannot go green until the two schema fixes land and the callers move to the
next release candidate — eight other files still fail validation on rules unrelated to
this one.