### PR TITLE
Temporarily drop update_allows_fetch_and_merge from rulesets

### DIFF
--- a/repos/consuldotnet.yaml
+++ b/repos/consuldotnet.yaml
@@ -28,7 +28,6 @@ rulesets:
       deletion: true
       non_fast_forward: true
       update: true
-      update_allows_fetch_and_merge: true
       required_status_checks:
         required_check:
           - context: all-required-checks-complete

--- a/repos/perfetto.yaml
+++ b/repos/perfetto.yaml
@@ -48,7 +48,6 @@ rulesets:
       deletion: true
       non_fast_forward: true
       update: true
-      update_allows_fetch_and_merge: true
     target: branch
     conditions:
       ref_name:
@@ -60,7 +59,6 @@ rulesets:
       deletion: true
       non_fast_forward: true
       update: true
-      update_allows_fetch_and_merge: true
     target: tag
     conditions:
       ref_name:


### PR DESCRIPTION
The provider bump to `6.11.1-gr.1` rejects this parameter as an invalid rule for both branch and tag targets:

```
Error: rule "update_allows_fetch_and_merge" is not valid for branch target
```

`terraform plan` fails outright, and because state is shared the two affected repositories block plans for **every** repository.

Verified as a provider regression, not a config problem: `perfetto.yaml` has carried this parameter unchanged since February and applied cleanly on 2026-07-29 under `6.9.0-gr.3`. The Terraform wiring is unchanged between the two releases.

Removing the parameter leaves the setting unmanaged, which is the state it was effectively in before. **Restore it once the provider issue is resolved.**

Tracked in G-Research/gr-oss#1429.