### PR TITLE
Phase 2: schema violations must fail before plan

### DIFF
--- a/repos/repo8.yaml
+++ b/repos/repo8.yaml
@@ -1,11 +1,11 @@
-description: Repository 8 created with Terraform
+description: Repository 8 xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+has_downloads: true
 visibility: public
 homepage_url: ""
 default_branch: main
 has_issues: true
 has_projects: true
 has_wiki: false
-has_downloads: false
 allow_merge_commit: true
 allow_rebase_merge: false
 allow_squash_merge: false


### PR DESCRIPTION
Deliberately invalid. Two GitHub-imposed constraints violated in `repos/repo8.yaml`:

- `description` is 353 characters (limit 350 — GitHub rejects longer with a 422)
- `has_downloads: true` (GitHub removed the Downloads feature and will not accept it)

Expected: `validate` fails citing both file and JSON path, and `terraform-plan` never runs.

Not for merge — closed once the result is recorded.