### PR TITLE
Phase 3: create a repository with default_branch master

### DIFF
--- a/repos/test-master-default.yaml
+++ b/repos/test-master-default.yaml
@@ -1,0 +1,18 @@
+description: Phase 3 test - repository created with a non-main default branch
+visibility: public
+default_branch: master
+has_issues: true
+has_projects: false
+has_wiki: false
+has_downloads: false
+allow_merge_commit: true
+allow_rebase_merge: false
+allow_squash_merge: true
+allow_auto_merge: false
+allow_update_branch: false
+web_commit_signoff_required: false
+delete_branch_on_merge: true
+is_template: false
+archived: false
+has_discussions: false
+vulnerability_alerts_enabled: true


### PR DESCRIPTION
Exercises the `rename = true` fix on `github_branch_default`.

`auto_init` creates the repository with a single `main` branch, then the default is pointed at `master`, which does not exist yet. Before the fix this failed at apply with a 422 and left the repository with the wrong default.

Expected: apply succeeds, `test-master-default` has default branch `master` and no `main` branch, and a follow-up plan is clean — the latter confirms `lifecycle { ignore_changes = [rename] }` does not leave a perpetual diff.