### PR TITLE
Phase 3: team reviewer without repository access

### DIFF
--- a/repos/test-master-default.yaml
+++ b/repos/test-master-default.yaml
@@ -32,5 +32,8 @@ environments:
       tag_patterns:
         - v*
   - environment: staging
+    reviewers:
+      teams:
+        - foo-bar-team
     deployment_policy:
       policy_type: protected_branches


### PR DESCRIPTION
Adds `foo-bar-team` as a reviewer on the `staging` environment. That team has **no access** to `test-master-default` — confirmed via the API, no team has access to it.

The developer guide warns:

> Teams specified as reviewers must have repository access first, otherwise Terraform applies successfully but the teams are not added as reviewers and the next plan/apply keeps showing them as proposed changes.

This confirms whether that is still true. If it is, the apply will succeed, the team will be absent from the environment on GitHub, and a follow-up plan will propose the same change again — a silent perpetual diff.