### PR TITLE
DO NOT MERGE - live-fire test of the protected owner guard

### DIFF
--- a/organisation/members.yaml
+++ b/organisation/members.yaml
@@ -1,6 +1,6 @@
 members:
     - username: dev-milos
-      role: owner
+      role: member
       teams:
         - name: foo-bar-team
           role: maintainer
@@ -8,5 +8,3 @@ members:
           role: maintainer
         - name: security-review
           role: maintainer
-    - username: pavlovic-ivan
-      role: owner


### PR DESCRIPTION
> [!CAUTION]
> **Do not merge.** This pull request deliberately removes one organisation owner and demotes the other. It exists only to prove the guard rejects it.

Now that `organisation/members.yaml` exists and memberships are in Terraform state, omitting an owner is a real `destroy` — which removes that person from the organisation, along with their teams and repository access.

Two rules under test at once:

| Change | Expected |
|---|---|
| `pavlovic-ivan` removed entirely | rejected — protected identities cannot be removed |
| `dev-milos` demoted from `owner` to `member` | rejected — protected identities cannot be demoted |

Expected outcome: `validate` fails, `terraform-plan` is skipped, and no `Terraform plan` check-run is produced — so the pull request is unmergeable even by accident.

Closed as soon as the result is recorded.