### PR TITLE
Phase 5: team visibility and notification changes, plus a new team

### DIFF
--- a/organisation/teams.yaml
+++ b/organisation/teams.yaml
@@ -1,9 +1,9 @@
 teams:
     - name: foo-bar-team
       slug: foo-bar-team
-      description: A big foo bar team
-      visibility: visible
-      notifications: true
+      description: A big foo bar team, now secret
+      visibility: secret
+      notifications: false
     - name: platform_core
       slug: platform_core
       description: Underscore in the name, to exercise real slug capture
@@ -11,6 +11,10 @@ teams:
       notifications: true
     - name: security-review
       slug: security-review
-      description: Secret team with notifications disabled
-      visibility: secret
-      notifications: false
+      description: No longer secret
+      visibility: visible
+      notifications: true
+    - name: release_engineering
+      description: Added by config, never existed on GitHub
+      visibility: visible
+      notifications: true


### PR DESCRIPTION
Exercises the team translation in both directions and the create path.

| Team | Change |
|---|---|
| `foo-bar-team` | `visible` to `secret`, notifications on to off |
| `security-review` | `secret` to `visible`, notifications off to on |
| `release_engineering` | new team, no `slug` since it does not exist yet |

Expected: two changes and one create. The new team must be a plain create rather than an import — the import blocks iterate staged bootstrap entries only, and this one was never staged.

Settings will be checked against the API after apply, not taken from the plan.