### PR TITLE
DO NOT MERGE - measure coupling between org and repo config

### DIFF
--- a/organisation/teams.yaml
+++ b/organisation/teams.yaml
@@ -7,7 +7,7 @@ teams:
     - name: platform_core
       slug: platform_core
       description: Underscore in the name, to exercise real slug capture
-      visibility: visible
+      visibility: banana
       notifications: true
     - name: security-review
       slug: security-review

--- a/repos/repo9.yaml
+++ b/repos/repo9.yaml
@@ -1,4 +1,4 @@
-description: Repository 9 created with Terraform tada
+description: Phase 5 coupling probe - a perfectly valid repository change
 visibility: public
 homepage_url: ""
 default_branch: master


### PR DESCRIPTION
> [!NOTE]
> Measurement, not a proposal. Closed once the result is recorded.

One valid repository change (`repo9` description) and one invalid organisation value (`visibility: banana`) in the same pull request.

The separate-workspace split was deliberately deferred, so organisation and repository config share a workspace and a single validate gate. This measures what that costs in practice: whether a broken organisation config stops repository work from proceeding.

Locally the repository config validates fine on its own and the organisation config fails. The question is what the pipeline does with the combination.