### PR TITLE
Phase 5: team membership changes

### DIFF
--- a/organisation/members.yaml
+++ b/organisation/members.yaml
@@ -6,7 +6,7 @@ members:
           role: maintainer
         - name: platform_core
           role: maintainer
-        - name: security-review
-          role: maintainer
+        - name: release_engineering
+          role: member
     - username: pavlovic-ivan
       role: owner


### PR DESCRIPTION
Exercises `github_team_membership` in both directions.

| Change | Expected |
|---|---|
| membership of `security-review` dropped | destroy |
| membership of `release_engineering` added | create |

The `member` role on the new membership is deliberate. GitHub reports organisation owners as maintainers of every team they belong to, so declaring `member` for an owner may never converge — if so, the follow-up plan will keep proposing the same change. Worth knowing either way, since the config is free to declare it.