### PR TITLE
Restore maintainer role to stop the perpetual diff

### DIFF
--- a/organisation/members.yaml
+++ b/organisation/members.yaml
@@ -7,6 +7,6 @@ members:
         - name: platform_core
           role: maintainer
         - name: release_engineering
-          role: member
+          role: maintainer
     - username: pavlovic-ivan
       role: owner


### PR DESCRIPTION
Reverts the deliberate `role: member` from the membership test.

GitHub reports organisation owners as maintainers of every team they belong to, so `member` never converges: apply reports success, GitHub keeps `maintainer`, and the next plan proposes the same change again.

Recorded as G-Research/gr-oss#1434. Reverting so the baseline plan returns to no changes before the remaining phases.