### PR TITLE
Resolve drift: drop the team reviewer GitHub never accepted

### DIFF
--- a/repos/test-master-default.yaml
+++ b/repos/test-master-default.yaml
@@ -32,8 +32,5 @@ environments:
       tag_patterns:
         - v*
   - environment: staging
-    reviewers:
-      teams:
-        - foo-bar-team
     deployment_policy:
       policy_type: protected_branches


### PR DESCRIPTION
The team has no access to this repository, so GitHub dropped it silently. The refreshed plan in drift-check keeps proposing removal of the now-empty `reviewers` block.

Removing it from config adopts reality and settles the divergence. Part of clearing genuine drift so the drift PR lifecycle can be observed.