### PR TITLE
Clear the remaining drift so the drift PR lifecycle can be observed

### DIFF
--- a/config/import-config.yaml
+++ b/config/import-config.yaml
@@ -10,6 +10,7 @@
 ignored_repos:
   - "gr-oss-developers/github-configuration-self-service"
   - "gr-oss-developers/github-configuration"
+  - "gr-oss-developers/pr-dashboard"
 
 # List of repositories to be imported by the importer.
 #

--- a/repos/ospo-platform.yaml
+++ b/repos/ospo-platform.yaml
@@ -21,6 +21,4 @@ archived: false
 has_discussions: false
 vulnerability_alerts_enabled: false
 push_collaborators:
-  - stackedsax
-  - tabathad
   - c-rindi

--- a/repos/perfetto.yaml
+++ b/repos/perfetto.yaml
@@ -65,3 +65,10 @@ rulesets:
         include:
           - refs/tags/v*
 vulnerability_alerts_enabled: true
+environments:
+  - environment: docker-hub
+    can_admins_bypass: false
+    deployment_policy:
+      policy_type: selected_branches_and_tags
+      tag_patterns:
+        - v*


### PR DESCRIPTION
Three genuine divergences, each resolved the way an operator would rather than by merging the drift pull request wholesale.

| Divergence | Resolution |
|---|---|
| `pr-dashboard` exists but is not managed here | added to `ignored_repos` |
| `perfetto` has a `docker-hub` environment absent from config | adopted into config |
| `ospo-platform` lists two push collaborators who left the organisation | removed from config |

The two collaborators were confirmed to be non-members with no access, so config was claiming access that does not exist.

Purpose: get the plan to report no changes, so the drift PR close-and-cleanup path can be exercised. That path is otherwise untested.