### PR TITLE
DO NOT MERGE - verify the non-converging role is now rejected

### DIFF
--- a/organisation/members.yaml
+++ b/organisation/members.yaml
@@ -7,6 +7,6 @@ members:
         - name: platform_core
           role: maintainer
         - name: release_engineering
-          role: maintainer
+          role: member
     - username: pavlovic-ivan
       role: owner


### PR DESCRIPTION
> Verification only. Closed once the result is recorded.

Restores the exact configuration that produced a perpetual diff during release testing: an organisation owner declared with `role: member` on a team.

Expected: `validate` rejects it before `terraform-plan` runs, so the workspace never sees it.