### PR TITLE
DO NOT MERGE - verify organisation resources render in the plan summary

### DIFF
--- a/organisation/teams.yaml
+++ b/organisation/teams.yaml
@@ -1,7 +1,7 @@
 teams:
     - name: foo-bar-team
       slug: foo-bar-team
-      description: A big foo bar team, now secret
+      description: A big foo bar team, description touched to exercise the plan summary
       visibility: secret
       notifications: false
     - name: platform_core


### PR DESCRIPTION
> Verification only. Closed once the result is recorded.

A team description change, so the plan touches a `github_team` and the summary has something organisation-level to render. Previously this appeared as `unknown type`.